### PR TITLE
feat: add PRLQN functions for seventh chords in Tonnetz Spaces

### DIFF
--- a/src/test/tonnetz.test.ts
+++ b/src/test/tonnetz.test.ts
@@ -92,4 +92,89 @@ describe('tonnetz-tests', () => {
         expect(transform([10, 1, 5], "plprlplrl")).toEqual([8, 0, 3]);
         expect(transform([11, 2, 6], "plprlplrl")).toEqual([9, 1, 4]);
     })
+
+    it('tonnetzTransformations "f" function to "normal form"', () => {
+        expect(transform([0, 4, 7], "f")).toEqual([7, 10, 2]);
+        expect(transform([0, 4, 7], "ff")).toEqual([0, 4, 7]);
+        expect(transform([9, 0, 4], "f")).toEqual([2, 6, 9]);
+        expect(transform([9, 0, 4], "ff")).toEqual([9, 0, 4]);
+
+        expect(transform([2, 6, 9], "f")).toEqual([9, 0, 4]);
+        expect(transform([2, 5, 9], "f")).toEqual([7, 11, 2]);
+        expect(transform([10, 2, 5], "f")).toEqual([5, 8, 0]);
+        expect(transform([5, 9, 0], "f")).toEqual([0, 3, 7]);
+        expect(transform([4, 7, 11], "f")).toEqual([9, 1, 4]);
+    })
+
+    it('tonnetzTransformations "n" function to "normal form"', () => {
+        expect(transform([0, 4, 7], "n")).toEqual([5, 8, 0]);
+        expect(transform([0, 4, 7], "nn")).toEqual([0, 4, 7]);
+        expect(transform([0, 3, 7], "n")).toEqual([7, 11, 2]);
+        expect(transform([0, 3, 7], "nn")).toEqual([0, 3, 7]);
+
+        expect(transform([7, 11, 2], "n")).toEqual([0, 3, 7]);
+        expect(transform([9, 0, 4], "n")).toEqual([4, 8, 11]);
+        expect(transform([5, 9, 0], "n")).toEqual([10, 1, 5]);
+        expect(transform([2, 6, 9], "n")).toEqual([7, 10, 2]);
+        expect(transform([2, 5, 9], "n")).toEqual([9, 1, 4]);
+    })
+
+    it('tonnetzTransformations "s" function to "normal form"', () => {
+        expect(transform([0, 4, 7], "s")).toEqual([1, 4, 8]);
+        expect(transform([0, 4, 7], "ss")).toEqual([0, 4, 7]);
+        expect(transform([0, 3, 7], "s")).toEqual([11, 3, 6]);
+        expect(transform([0, 3, 7], "ss")).toEqual([0, 3, 7]);
+
+        expect(transform([7, 11, 2], "s")).toEqual([8, 11, 3]);
+        expect(transform([9, 0, 4], "s")).toEqual([8, 0, 3]);
+        expect(transform([5, 9, 0], "s")).toEqual([6, 9, 1]);
+        expect(transform([2, 6, 9], "s")).toEqual([3, 6, 10]);
+        expect(transform([2, 5, 9], "s")).toEqual([1, 5, 8]);
+    })
+
+    it('tonnetzTransformations "h" function to "normal form"', () => {
+        expect(transform([0, 4, 7], "h")).toEqual([8, 11, 3]);
+        expect(transform([0, 4, 7], "hh")).toEqual([0, 4, 7]);
+        expect(transform([0, 3, 7], "h")).toEqual([4, 8, 11]);
+        expect(transform([0, 3, 7], "hh")).toEqual([0, 3, 7]);
+
+        expect(transform([7, 11, 2], "h")).toEqual([3, 6, 10]);
+        expect(transform([9, 0, 4], "h")).toEqual([1, 5, 8]);
+        expect(transform([5, 9, 0], "h")).toEqual([1, 4, 8]);
+        expect(transform([2, 6, 9], "h")).toEqual([10, 1, 5]);
+        expect(transform([2, 5, 9], "h")).toEqual([6, 10, 1]);
+    })
+
+    it('tonnetzTransformations "t" function to "normal form"', () => {
+        expect(transform([0, 4, 7], "t")).toEqual([6, 10, 1]);
+        expect(transform([0, 4, 7], "tt")).toEqual([0, 4, 7]);
+        expect(transform([0, 3, 7], "t")).toEqual([6, 9, 1]);
+        expect(transform([0, 3, 7], "tt")).toEqual([0, 3, 7]);
+
+        expect(transform([7, 11, 2], "t")).toEqual([1, 5, 8]);
+        expect(transform([9, 0, 4], "t")).toEqual([3, 6, 10]);
+        expect(transform([5, 9, 0], "t")).toEqual([11, 3, 6]);
+        expect(transform([2, 6, 9], "t")).toEqual([8, 0, 3]);
+        expect(transform([2, 5, 9], "t")).toEqual([8, 11, 3]);
+    })
+
+    it('tonnetzTransformations "pt6, lt6, rt6" function to "normal form"', () => {
+        expect(transform([0, 4, 7], "pt")).toEqual([6, 9, 1]);
+        expect(transform([0, 4, 7], "lt")).toEqual([10, 1, 5]);
+        expect(transform([0, 4, 7], "rt")).toEqual([3, 6, 10]);
+
+        expect(transform([0, 3, 7], "pt")).toEqual([6, 10, 1]);
+        expect(transform([0, 3, 7], "lt")).toEqual([2, 6, 9]);
+        expect(transform([0, 3, 7], "rt")).toEqual([9, 1, 4]);
+    })
+
+    it('tonnetzTransformations "compositions" function to "normal form"', () => {
+        expect(transform([0, 4, 7], "hsf")).toEqual([2, 5, 9]);
+        expect(transform([0, 3, 7], "hsf")).toEqual([10, 2, 5]);
+        expect(transform([0, 4, 7], "hsftn")).toEqual([3, 7, 10]);
+        expect(transform([0, 3, 7], "hsftn")).toEqual([9, 0, 4]);
+
+        expect(transform([0, 4, 7], "hsftnprpl")).toEqual([2, 6, 9]);
+        expect(transform([0, 3, 7], "hsftnprpl")).toEqual([10, 1, 5]);
+    })
 });

--- a/src/tonnetz.ts
+++ b/src/tonnetz.ts
@@ -12,6 +12,12 @@ export type ObjectTransformations = {
     [key: string]: TransformationFunctions
 }
 
+export type TransformationFunctionsSeventhChords = (tetrachord: Tetrachord, tonnetz: TonnetzSpaces) => Tetrachord;
+
+export type ObjectTransformationsSeventhChords = {
+    [key: string]: TransformationFunctionsSeventhChords
+}
+
 export type ChordGenerationFunctions = (rootNote: number, tonnetz: TonnetzSpaces) => TriadChord | Tetrachord;
 
 export type ChordGenerators = {
@@ -53,6 +59,19 @@ export const dominantSeventChord = (rootNote: number, tonnetz: TonnetzSpaces): T
 
     const dominant7: Tetrachord = [firstNote, secondNote, thirdNote, fourthNote];
     return dominant7;
+}
+
+export const majorSeventhChord = (rootNote: number, tonnetz: TonnetzSpaces): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+
+    const firstNote = ((rootNote % modulo) + modulo) % modulo;
+    const secondNote = ((rootNote + b % modulo) + modulo) % modulo;
+    const thirdNote = ((rootNote + (a + b) % modulo) + modulo) % modulo;
+    const fourthNote = ((rootNote + (2 * b + a) % modulo) + modulo) % modulo;
+
+    const maj7: Tetrachord = [firstNote, secondNote, thirdNote, fourthNote];
+    return maj7;
 }
 
 export const minorSeventhChord = (rootNote: number, tonnetz: TonnetzSpaces): Tetrachord => {
@@ -190,6 +209,7 @@ export const CHORD_TYPES: ChordGenerators = {
     "m": minorChordFromTonnetz,
     "min": minorChordFromTonnetz,
     "7": dominantSeventChord,
+    "maj7": majorSeventhChord,
     "m7": minorSeventhChord,
     "hdim7": halfDiminishedChord,
     "aug": augmentedTriadChord,
@@ -311,5 +331,397 @@ export const boretzRegions = (rootNote: number, tonnetz: TonnetzSpaces = [3, 4, 
     const treeChords: Map<Tetrachord, Tetrachord[]> = new Map();
     treeChords.set(diminished7Chord, arrayTargetSet)
     return treeChords;
+}
+
+export const firstChordComparison = (reduceModN: Tetrachord, compareOne: Tetrachord): boolean => {
+    const firstChordCompare = reduceModN.map((item, index) => item === compareOne[index]);
+    const equalFirstChord: boolean = firstChordCompare.every(item => item === true);
+    return equalFirstChord;
+}
+
+export const secondChordComparison = (reduceModN: Tetrachord, compareTwo: Tetrachord): boolean => {
+    const secondChordCompare = reduceModN.map((item, index) => item === compareTwo[index]);
+    const equalSecondChord: boolean = secondChordCompare.every(item => item === true);
+    return equalSecondChord;
+}
+
+export const p12: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const p: number = (a - b);
+
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, dominantSeventChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, minorSeventhChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    const transformedChord: Tetrachord = [...reduceModN];
+    if (transformedChord[1] % modulo !== (transformedChord[0] + b) % modulo) {
+        transformedChord[1] -= p;
+    } else {
+        transformedChord[1] += p;
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const p14: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const p: number = (a - b);
+
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, dominantSeventChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, majorSeventhChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    const transformedChord: Tetrachord = [...reduceModN];
+    if (transformedChord[3] % modulo !== (transformedChord[0] + (2 * b + a)) % modulo) {
+        transformedChord[3] -= p;
+    } else {
+        transformedChord[3] += p;
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const p23: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const p: number = (a - b);
+
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, minorSeventhChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, halfDiminishedChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    const transformedChord: Tetrachord = [...reduceModN];
+    if (transformedChord[2] % modulo !== (transformedChord[0] + (a + b)) % modulo) {
+        transformedChord[2] -= p;
+    } else {
+        transformedChord[2] += p;
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const p35: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const p: number = (a - b);
+
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, halfDiminishedChord(reduceModN[0], tonnetz));
+    const equalToChordTwo = secondChordComparison(reduceModN, diminishedSeventhChord(reduceModN[0], tonnetz));
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    const transformedChord: Tetrachord = [...reduceModN];
+    if (transformedChord[3] % modulo !== (transformedChord[0] + (2 * a + b)) % modulo) {
+        transformedChord[3] -= p;
+    } else {
+        transformedChord[3] += p;
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const r12: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, dominantSeventChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, minorSeventhChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = minorSeventhChord(transformedChord[0] - a, tonnetz)
+    } else {
+        transformedChord = dominantSeventChord(transformedChord[0] + a, tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const r23: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, minorSeventhChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, halfDiminishedChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = halfDiminishedChord(transformedChord[0] - a, tonnetz)
+    } else {
+        transformedChord = minorSeventhChord(transformedChord[0] + a, tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const r42: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, majorSeventhChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, minorSeventhChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = minorSeventhChord(transformedChord[0] - a, tonnetz)
+    } else {
+        transformedChord = majorSeventhChord(transformedChord[0] + a, tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const r35: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, halfDiminishedChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, diminishedSeventhChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = diminishedSeventhChord(transformedChord[0] - a, tonnetz)
+    } else {
+        transformedChord = halfDiminishedChord(transformedChord[0] + a, tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const r53: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, diminishedSeventhChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, halfDiminishedChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = halfDiminishedChord(transformedChord[0] - a, tonnetz)
+    } else {
+        transformedChord = diminishedSeventhChord(transformedChord[0] + a, tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const l13: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, dominantSeventChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, halfDiminishedChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = halfDiminishedChord(transformedChord[0] + b, tonnetz)
+    } else {
+        transformedChord = dominantSeventChord(transformedChord[0] - b, tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const l15: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, dominantSeventChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, diminishedSeventhChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = diminishedSeventhChord(transformedChord[0] + b, tonnetz)
+    } else {
+        transformedChord = dominantSeventChord(transformedChord[0] - b, tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const l42: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, majorSeventhChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, minorSeventhChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = minorSeventhChord(transformedChord[0] + b, tonnetz)
+    } else {
+        transformedChord = majorSeventhChord(transformedChord[0] - b, tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const q43: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, majorSeventhChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, halfDiminishedChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = halfDiminishedChord(transformedChord[0] + (b - a), tonnetz)
+    } else {
+        transformedChord = majorSeventhChord(transformedChord[0] - (b - a), tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const q15: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, dominantSeventChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, diminishedSeventhChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = diminishedSeventhChord(transformedChord[0] + (b - a), tonnetz)
+    } else {
+        transformedChord = dominantSeventChord(transformedChord[0] - (b - a), tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const rr35: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, halfDiminishedChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, diminishedSeventhChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = diminishedSeventhChord(transformedChord[0] + (2 * a), tonnetz)
+    } else {
+        transformedChord = halfDiminishedChord(transformedChord[0] - (2 * a), tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const qq51: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, diminishedSeventhChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, dominantSeventChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = dominantSeventChord(transformedChord[0] + (c - a), tonnetz)
+    } else {
+        transformedChord = diminishedSeventhChord(transformedChord[0] - (c - a), tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const n51: TransformationFunctionsSeventhChords = (chordFromTonnetz, tonnetz): Tetrachord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+
+    const equalToChordOne = firstChordComparison(reduceModN, diminishedSeventhChord(reduceModN[0], tonnetz))
+    const equalToChordTwo = secondChordComparison(reduceModN, dominantSeventChord(reduceModN[0], tonnetz))
+
+    if (equalToChordOne === equalToChordTwo) return reduceModN;
+
+    let transformedChord: Tetrachord = [...reduceModN];
+    if (equalToChordOne) {
+        transformedChord = dominantSeventChord(transformedChord[0] + c, tonnetz)
+    } else {
+        transformedChord = diminishedSeventhChord(transformedChord[0] - c, tonnetz)
+    }
+    const targetTetraChord = chordNotesToModN(transformedChord, modulo);
+    return targetTetraChord;
+}
+
+export const SEVENTHSTRANFORMATIONS: ObjectTransformationsSeventhChords = {
+    "p12": p12,
+    "p14": p14,
+    "p23": p23,
+    "p35": p35,
+    "r12": r12,
+    "r23": r23,
+    "r42": r42,
+    "r35": r35,
+    "r53": r53,
+    "l13": l13,
+    "l15": l15,
+    "l42": l42,
+    "q43": q43,
+    "q15": q15,
+    "rr35": rr35,
+    "qq51": qq51,
+    "n51": n51
+}
+
+export const seventhsTransform = (chord: Tetrachord, transformation: string, tonnetz: TonnetzSpaces = [3, 4, 5]): Tetrachord => {
+    const transformations = transformation.split("-");
+    let transformedChord: Tetrachord = [...chord];
+    for (let i = 0; i < transformations.length; i++) {
+        const validTransformation = transformations[i];
+        if (validTransformation) {
+            transformedChord = SEVENTHSTRANFORMATIONS[validTransformation](transformedChord, tonnetz);
+        }
+    }
+    return transformedChord;
 }
 

--- a/src/tonnetz.ts
+++ b/src/tonnetz.ts
@@ -203,6 +203,88 @@ export const relativeTransform: TransformationFunctions = (chordFromTonnetz, ton
     return targetTriadChord;
 }
 
+
+export const f: TransformationFunctions = (chordFromTonnetz, tonnetz): TriadChord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const f: number = (a + b)
+
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+    let rootPositionTriad: TriadChord = sortingTriadChord(reduceModN, tonnetz);
+    if (rootPositionTriad[1] % modulo === (rootPositionTriad[0] + b) % modulo) {
+        rootPositionTriad = minorChordFromTonnetz(rootPositionTriad[0] + f, tonnetz);
+    } else {
+        rootPositionTriad = majorChordFromTonnetz(rootPositionTriad[0] - f, tonnetz);
+    }
+    const targetTriadChord = chordNotesToModN(rootPositionTriad, modulo);
+    return targetTriadChord;
+}
+
+export const n: TransformationFunctions = (chordFromTonnetz, tonnetz): TriadChord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const n: number = c;
+
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+    let rootPositionTriad: TriadChord = sortingTriadChord(reduceModN, tonnetz);
+    if (rootPositionTriad[1] % modulo === (rootPositionTriad[0] + b) % modulo) {
+        rootPositionTriad = minorChordFromTonnetz(rootPositionTriad[0] + n, tonnetz);
+    } else {
+        rootPositionTriad = majorChordFromTonnetz(rootPositionTriad[0] - n, tonnetz);
+    }
+    const targetTriadChord = chordNotesToModN(rootPositionTriad, modulo);
+    return targetTriadChord;
+}
+
+export const s: TransformationFunctions = (chordFromTonnetz, tonnetz): TriadChord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const s: number = (b - a);
+
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+    let rootPositionTriad: TriadChord = sortingTriadChord(reduceModN, tonnetz);
+    if (rootPositionTriad[1] % modulo === (rootPositionTriad[0] + b) % modulo) {
+        rootPositionTriad = minorChordFromTonnetz(rootPositionTriad[0] + s, tonnetz);
+    } else {
+        rootPositionTriad = majorChordFromTonnetz(rootPositionTriad[0] - s, tonnetz);
+    }
+    const targetTriadChord = chordNotesToModN(rootPositionTriad, modulo);
+    return targetTriadChord;
+}
+
+export const h: TransformationFunctions = (chordFromTonnetz, tonnetz): TriadChord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const h: number = (2 * b);
+
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+    let rootPositionTriad: TriadChord = sortingTriadChord(reduceModN, tonnetz);
+    if (rootPositionTriad[1] % modulo === (rootPositionTriad[0] + b) % modulo) {
+        rootPositionTriad = minorChordFromTonnetz(rootPositionTriad[0] + h, tonnetz);
+    } else {
+        rootPositionTriad = majorChordFromTonnetz(rootPositionTriad[0] - h, tonnetz);
+    }
+    const targetTriadChord = chordNotesToModN(rootPositionTriad, modulo);
+    return targetTriadChord;
+}
+
+export const t6: TransformationFunctions = (chordFromTonnetz, tonnetz): TriadChord => {
+    const [a, b, c] = tonnetz;
+    const modulo = a + b + c;
+    const h: number = (2 * a);
+
+    const reduceModN = chordNotesToModN(chordFromTonnetz);
+    let rootPositionTriad: TriadChord = sortingTriadChord(reduceModN, tonnetz);
+    if (rootPositionTriad[1] % modulo === (rootPositionTriad[0] + b) % modulo) {
+        rootPositionTriad = majorChordFromTonnetz(rootPositionTriad[0] + h, tonnetz);
+    } else {
+        rootPositionTriad = minorChordFromTonnetz(rootPositionTriad[0] - h, tonnetz);
+    }
+    const targetTriadChord = chordNotesToModN(rootPositionTriad, modulo);
+    return targetTriadChord;
+}
+
+
 export const CHORD_TYPES: ChordGenerators = {
     "M": majorChordFromTonnetz,
     "maj": majorChordFromTonnetz,
@@ -225,6 +307,11 @@ export const TRANSFORMATIONS: ObjectTransformations = {
     "p": parallelTransform,
     "l": leadingToneTransform,
     "r": relativeTransform,
+    "f": f,
+    "n": n,
+    "s": s,
+    "h": h,
+    "t": t6
 };
 
 export const transform = (chord: TriadChord, transformation: string, tonnetz: TonnetzSpaces = [3, 4, 5]): TriadChord => {


### PR DESCRIPTION
- [x] Adds 17 new seventh chord transformations (based on the paper by Sonia Cannas and Moreno Andreatta)
- [x]  Separate the transformation logic with a new function for seventh chords (same style as `transform()`).
- [x] Since the new transformations have several characters, `.split("-")` is used.
- [x] If the chord does not support the transformation, it returns the same chord.
  
- [x] Example of use that returns `C7 => F#m7`:

```typescript
seventhsTransform([0,4,7,10], "p14-r42-l42-q43-rr35-qq51-l15-n51-l13-r23")
```